### PR TITLE
Use GNUInstallDirs for define install paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,13 +20,8 @@ SET(PRJ_DESCRIPTION
 Input tables themselves are in subpackages."
     )
 
-IF(CMAKE_SYSTEM_PROCESSOR MATCHES "64")
-    SET(LIB_DIR "${CMAKE_INSTALL_PREFIX}/lib64" CACHE PATH "Library dir")
-ELSE(CMAKE_SYSTEM_PROCESSOR MATCHES "64")
-    SET(LIB_DIR "${CMAKE_INSTALL_PREFIX}/lib" CACHE PATH "Library dir")
-ENDIF(CMAKE_SYSTEM_PROCESSOR MATCHES "64")
-SET(LIBEXEC_DIR "${LIB_DIR}" CACHE PATH "LIBEXEC dir")
-SET(DATA_DIR "/usr/share")
+INCLUDE(GNUInstallDirs)
+SET(DATA_DIR ${CMAKE_INSTALL_DATADIR})
 
 ####################################################################
 # Building
@@ -36,6 +31,6 @@ ADD_SUBDIRECTORY(tables)
 ####################################################################
 # Installing
 #
-SET(PRJ_DOC_DIR "${DATA_DIR}/doc/ibus-table-chinese")
+SET(PRJ_DOC_DIR "${CMAKE_INSTALL_DOCDIR}")
 INSTALL(FILES AUTHORS README ChangeLog COPYING DESTINATION ${PRJ_DOC_DIR})
 


### PR DESCRIPTION
This change simplifies installation for package maintainers of Linux distributions.

Also cleanup unused variables.